### PR TITLE
Remove gh-pages circleci config, was v1 and should now be managed by the master file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-# Configuration for CircleCI
-
-general:
-  branches:
-    ignore:
-      - gh-pages


### PR DESCRIPTION
This could also make #13 obsolete. Let's merge this one first and see how circle reacts.